### PR TITLE
Add favicons task

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -117,6 +117,7 @@ module.exports = yeoman.generators.Base.extend({
         this.copy('tasks/images.js', 'tasks/images.js');
         this.copy('tasks/scripts.js', 'tasks/scripts.js');
         this.copy('tasks/icons.js', 'tasks/icons.js');
+        this.copy('tasks/favicons.js', 'tasks/favicons.js');
         if (this.fabricator) {
           this.copy('tasks/styleguide.js', 'tasks/styleguide.js');
         }
@@ -142,6 +143,7 @@ module.exports = yeoman.generators.Base.extend({
       this.mkdir(this.assets + 'svg');
       this.mkdir(this.assets + 'fonts');
       this.mkdir(this.assets + 'icons');
+      this.mkdir(this.assets + 'favicons');
 
       if (this.bootstrapSass) {
         this.copy('assets/sass/bootstrap.scss', this.assets + 'sass/bootstrap.scss');

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -13,6 +13,7 @@ require(config.tasks + 'images')();             // $ gulp img
 require(config.tasks + 'styles')();             // $ gulp styles
 require(config.tasks + 'scripts')();            // $ gulp scripts
 require(config.tasks + 'icons')();              // $ gulp icons
+require(config.tasks + 'favicons')();           // $ gulp favicons
 require(config.tasks + 'clean')();              // $ gulp clean<% if (fabricator) { %>
 require(config.tasks + 'styleguide')();         // $ gulp styleguide<% } %>
 require(config.tasks + 'server')();             // $ gulp serve
@@ -45,5 +46,5 @@ gulp.task('build',['clean'], function() {
  * Default task
  */
 gulp.task('default', ['clean'], function(done){
-  runSequence(['css-vendors', 'js-vendors', 'fonts-vendors', 'polyfills-vendors', 'img', 'icons', 'styles', 'scripts'<% if (fabricator) { %>, 'styleguide-styles', 'styleguide-scripts'<% } %>]<% if (fabricator) { %>, 'styleguide'<% } %>, done);
+  runSequence(['css-vendors', 'js-vendors', 'fonts-vendors', 'polyfills-vendors', 'img', 'icons', 'styles', 'scripts'<% if (fabricator) { %>, 'styleguide-styles', 'styleguide-scripts'<% } %>], 'favicons'<% if (fabricator) { %>, 'styleguide'<% } %>, done);
 });

--- a/app/templates/tasks/favicons.js
+++ b/app/templates/tasks/favicons.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var gulp          = require('gulp'),
+    $             = require('gulp-load-plugins')(),
+    config        = require('../gulp_config.json');
+
+module.exports = function() {
+
+ /**
+  * Copy favicons in styleguide folder
+  */
+  gulp.task('favicons', function() {
+    return gulp.src(config.assets + 'favicons/*')
+      .pipe(gulp.dest(config.styleguide.dest));
+  });
+
+};


### PR DESCRIPTION
Simple task to copy `/assets/favicons/` content to the styleguide folder.

We should have a look at that for a future feature: https://www.npmjs.com/package/gulp-favicons
