### PR TITLE
Ask for deploy settings

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -43,6 +43,15 @@ module.exports = class extends Generator {
         message: 'What\'s the name of your project?',
         default: 'Toolbox'
       }, {
+        type: 'input',
+        name: 'remote',
+        message: 'What\'s the URL of your repo?',
+        default: function (answers) {
+          const slugName = slug(answers.name, {lower: true});
+          return `git@github.com:antistatique/${slugName}.git`;
+        },
+        store: true,
+      }, {
         type: 'checkbox',
         name: 'options',
         message: 'What would you like to use in your project?',
@@ -144,6 +153,7 @@ module.exports = class extends Generator {
         src: this.props.src,
         dest: this.props.dest,
         assets: this.props.src,
+        remote: this.props.remote,
       }
     );
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -44,8 +44,8 @@ module.exports = class extends Generator {
         default: 'Toolbox'
       }, {
         type: 'input',
-        name: 'remote',
-        message: 'What\'s the URL of your repo?',
+        name: 'repo',
+        message: 'What\'s the git URL of your repo?',
         default: function (answers) {
           const slugName = slug(answers.name, {lower: true});
           return `git@github.com:antistatique/${slugName}.git`;
@@ -134,6 +134,7 @@ module.exports = class extends Generator {
       {
         name: this.props.slug,
         assets: this.props.src,
+        repo: this.props.repo,
       }
     );
 

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "license": "MIT",
   "main": "index.html",
+  "repository": {
+    "type": "git",
+    "url": "<%= repo %>"
+  },
   "scripts": {
     "start": "toolbox serve",
     "build": "toolbox build",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "toolbox serve",
     "build": "toolbox build",
-    "deploy": "toolbox deploy"
+    "deploy": "toolbox build styleguide && toolbox deploy"
   },
   "browserslist": [
     "> 1% in CH",

--- a/generators/app/templates/_toolbox.json
+++ b/generators/app/templates/_toolbox.json
@@ -2,6 +2,7 @@
   "src": "<%= src %>",
   "dest": "<%= dest %>",
   "ghpages": "<%= dest %>",
+  "remote": "<%= remote %>",
   "images": [
     "<%= dest %>images/**/*"
   ],


### PR DESCRIPTION
We need that because the deploy script is run from the `node_modules/toolbox-utils` directory, which would make it deploy to the wrong repository.