### PR TITLE
fix svg-icon script generation

### DIFF
--- a/generators/app/templates/assets/base.js
+++ b/generators/app/templates/assets/base.js
@@ -1,4 +1,12 @@
 // You will use that file to import all your scripts
 // Ex: import gallery from './gallery'<% if (svgIcons) { %>
+import svgIcons from '../icons/svg-icons';
 
-import '../icons/svg-icons.js';<% } %>
+svgIcons(); // Must run as soon as possible<% } %>
+
+(function ($) {
+  $(document).ready(function () {
+    // Run your imported scripts
+    // Ex: gallery();
+  });
+})(jQuery);

--- a/generators/app/templates/assets/svg-icons.js
+++ b/generators/app/templates/assets/svg-icons.js
@@ -1,12 +1,13 @@
 const svgIcons = () => {
   const ajax = new XMLHttpRequest();
-  ajax.open('GET', '<%= iconsPath %>', true);
+  const svgPath = window.svgPath || 'icons/icons.svg';
+  ajax.open('GET', svgPath, true);
   ajax.send();
-  ajax.onload = function(e) {
+  ajax.onload = function (e) {
     var div = document.createElement('div');
     div.innerHTML = ajax.responseText;
     document.body.insertBefore(div, document.body.childNodes[0]);
-  }
+  };
 };
 
 export default svgIcons;


### PR DESCRIPTION
It was completely broken 😢 

The script will look for the sprite svg at the path: `icons/icons.svg`.

Before merging this, we have to add documentation about the `window.svgPath` snippet to be added in the html root to override the default path:

```html
<script type="text/javascript">
  window.svgPath = "/path/to/build/icons/icons.svg";
</script>
```