### PR TITLE
avoid inserting markup in page when icons fail to load

### DIFF
--- a/generators/app/templates/assets/svg-icons.js
+++ b/generators/app/templates/assets/svg-icons.js
@@ -1,6 +1,7 @@
 const svgIcons = () => {
   const ajax = new XMLHttpRequest();
-  const svgPath = window.svgPath || 'icons/icons.svg';
+  let svgPath = window.svgPath || 'icons/icons.svg';
+  try { svgPath = toolbox_data.svgPath } catch (e){}
   ajax.open('GET', svgPath, true);
   ajax.send();
   ajax.onload = function (e) {

--- a/generators/app/templates/assets/svg-icons.js
+++ b/generators/app/templates/assets/svg-icons.js
@@ -6,7 +6,9 @@ const svgIcons = () => {
   ajax.onload = function (e) {
     var div = document.createElement('div');
     div.innerHTML = ajax.responseText;
-    document.body.insertBefore(div, document.body.childNodes[0]);
+    if (ajax.status === 200) {
+      document.body.insertBefore(div, document.body.childNodes[0]);
+    }
   };
 };
 


### PR DESCRIPTION
- A simple test to avoid weird behaviors when icons are incorrectly set
- Add a possibility to use a js variable named `toolbox_data` instead of window to pass svgPath (useful with wordpress js injection : https://codex.wordpress.org/Function_Reference/wp_localize_script)